### PR TITLE
Create 23.08 branch

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: [ branch/22.08 ] # list all branches to check
+        branch: [ branch/22.08, branch/23.08 ] # list all branches to check
     
     steps:
       - uses: actions/checkout@v3

--- a/org.freedesktop.Sdk.Extension.mono6.json
+++ b/org.freedesktop.Sdk.Extension.mono6.json
@@ -1,10 +1,10 @@
 {
     "id": "org.freedesktop.Sdk.Extension.mono6",
-    "branch": "22.08",
+    "branch": "23.08",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "separate-locales": false,
     "appstream-compose": false,
     "modules": [


### PR DESCRIPTION
Some applications such as [com.inklestudios.Inky](https://github.com/flathub/com.inklestudios.Inky) still need this extension, and now that the 23.08 runtime is out, this extension also needs a 23.08 branch on Flathub. Since no one else has opened a PR or even an issue here, I thought I'd try taking up this task.

I also updated the runtime using the same commit I used for #24 (which is for the 22.08 branch that has not _yet_ reached EOL).