### PR TITLE
Mark 21.08 branch as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "skip-icons-check": true
+    "skip-icons-check": true,
+    "end-of-life": "21.08 Freedesktop runtime has reached EOL, therefore this extension is also EOL"
 }


### PR DESCRIPTION
Since the 23.08 runtime has been released, the 21.08 runtime is now EOL, and I thought I'd open this PR to ensure it's denoted as such. I didn't bother updating the sources like I did with #24 and #25 since this branch is, well, _EOL_.