### PR TITLE
Update runtime to 25.08

### DIFF
--- a/org.freedesktop.Sdk.Extension.mono6.json
+++ b/org.freedesktop.Sdk.Extension.mono6.json
@@ -1,10 +1,10 @@
 {
     "id": "org.freedesktop.Sdk.Extension.mono6",
-    "branch": "24.08",
+    "branch": "25.08",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "24.08",
+    "runtime-version": "25.08",
     "separate-locales": false,
     "modules": [
         {

--- a/org.freedesktop.Sdk.Extension.mono6.json
+++ b/org.freedesktop.Sdk.Extension.mono6.json
@@ -15,15 +15,26 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.mono-project.com/sources/mono/mono-6.12.0.199.tar.xz",
-                    "sha256": "c0850d545353a6ba2238d45f0914490c6a14a0017f151d3905b558f033478ef5",
+                    "url": "https://dl.winehq.org/mono/sources/mono/mono-6.14.1.tar.xz",
+                    "sha256": "3024c97c0bc8cbcd611c401d5f994528704108ceb31f31b28dea4783004d0820",
                     "x-checker-data": {
-                        "type": "html",
-                        "url": "https://download.mono-project.com/sources/mono/",
-                        "version-pattern": "mono-(6(?:\\.[\\d]+){3})\\.tar\\.xz",
-                        "url-template": "https://download.mono-project.com/sources/mono/mono-${version}.tar.xz",
-                        "is-main-source": true
+                        "is-main-source": true,
+                        "type": "anitya",
+                        "project-id": 6360,
+                        "url-template": "https://dl.winehq.org/mono/sources/mono/mono-$version.tar.xz",
+                        "versions": {
+                            "<": "7"
+                        },
+                        "stable-only": true
                     }
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "patches/0001-arm64-Fix-a-pointer-to-int-cast-size-mismatch.patch",
+                        "patches/0002-arm64-Fix-an-invalid-stack-read.patch",
+                        "patches/0003-arm64-Remove-an-unused-function.patch"
+                    ]
                 }
             ]
         },

--- a/org.freedesktop.Sdk.Extension.mono6.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.mono6.metainfo.xml
@@ -5,9 +5,12 @@
   <metadata_license>CC0-1.0</metadata_license>
   <name>Mono 6.x Sdk extension</name>
   <summary>Mono runtime, compiler and tools</summary>
-  <url type="homepage">https://www.mono-project.com/</url>
+  <url type="homepage">https://gitlab.winehq.org/mono/mono</url>
   <url type="bugtracker">https://github.com/flathub/org.freedesktop.Sdk.Extension.mono6</url>
   <releases>
+    <release version="6.14.1" date="2025-04-29">
+      <description></description>
+    </release>
     <release version="6.12.0.199" date="2023-07-27"/>
     <release version="6.12.0.182" date="2022-06-14"/>
     <release version="6.12.0.122" date="2021-02-23"/>

--- a/patches/0001-arm64-Fix-a-pointer-to-int-cast-size-mismatch.patch
+++ b/patches/0001-arm64-Fix-a-pointer-to-int-cast-size-mismatch.patch
@@ -1,0 +1,29 @@
+From 2224c6915a98f870cc9a3a9f9e3698e7b20e3d27 Mon Sep 17 00:00:00 2001
+From: Esme Povirk <esme@codeweavers.com>
+Date: Sat, 12 Apr 2025 20:31:54 +0000
+Subject: [PATCH 1/3] arm64: Fix a pointer-to-int cast size mismatch.
+
+---
+ mono/utils/mono-sigcontext.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/mono/utils/mono-sigcontext.h b/mono/utils/mono-sigcontext.h
+index 2153c1cad57..6426f44b7c7 100644
+--- a/mono/utils/mono-sigcontext.h
++++ b/mono/utils/mono-sigcontext.h
+@@ -492,6 +492,12 @@ typedef struct ucontext {
+ 	#define UCONTEXT_REG_SP(ctx) (((ucontext_t*)(ctx))->uc_mcontext.sp)
+ 	#define UCONTEXT_REG_R0(ctx) (((ucontext_t*)(ctx))->uc_mcontext.regs [ARMREG_R0])
+ 	#define UCONTEXT_GREGS(ctx) (&(((ucontext_t*)(ctx))->uc_mcontext.regs))
++	#define UCONTEXT_REG_SET_PC(ctx, val) do { \
++		UCONTEXT_REG_PC (ctx) = (gsize)(val); \
++		 } while (0)
++	#define UCONTEXT_REG_SET_SP(ctx, val) do { \
++		UCONTEXT_REG_SP (ctx) = (val); \
++		 } while (0)
+ #endif
+ 
+ #ifndef UCONTEXT_REG_SET_PC
+-- 
+2.51.0
+

--- a/patches/0002-arm64-Fix-an-invalid-stack-read.patch
+++ b/patches/0002-arm64-Fix-an-invalid-stack-read.patch
@@ -1,0 +1,35 @@
+From 637c318471f7fef325ac2f1858edcf66df3b81e0 Mon Sep 17 00:00:00 2001
+From: Esme Povirk <esme@codeweavers.com>
+Date: Sat, 12 Apr 2025 20:31:05 +0000
+Subject: [PATCH 2/3] arm64: Fix an invalid stack read.
+
+---
+ mono/mini/mini-arm64.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/mono/mini/mini-arm64.c b/mono/mini/mini-arm64.c
+index 9b32f424199..aba6ca3a41e 100644
+--- a/mono/mini/mini-arm64.c
++++ b/mono/mini/mini-arm64.c
+@@ -1737,9 +1737,15 @@ mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
+ static double
+ bitcast_r4_to_r8 (float f)
+ {
+-	float *p = &f;
+-
+-	return *(double*)p;
++	union {
++		float f;
++		double d;
++		guint64 i;
++	} u;
++	u.i = 0;
++	u.f = f;
++
++	return u.d;
+ }
+ 
+ static float
+-- 
+2.51.0
+

--- a/patches/0003-arm64-Remove-an-unused-function.patch
+++ b/patches/0003-arm64-Remove-an-unused-function.patch
@@ -1,0 +1,37 @@
+From ef69fc24043f4776f3d8e884898e1281c41b10fb Mon Sep 17 00:00:00 2001
+From: Esme Povirk <esme@codeweavers.com>
+Date: Sat, 12 Apr 2025 20:30:41 +0000
+Subject: [PATCH 3/3] arm64: Remove an unused function.
+
+---
+ mono/mini/mini-arm64.c | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/mono/mini/mini-arm64.c b/mono/mini/mini-arm64.c
+index cc6401d3514..9b32f424199 100644
+--- a/mono/mini/mini-arm64.c
++++ b/mono/mini/mini-arm64.c
+@@ -485,20 +485,6 @@ emit_cmpw_imm (guint8 *code, int sreg, int imm)
+ 	return code;
+ }
+ 
+-static __attribute__ ((__warn_unused_result__)) guint8*
+-emit_cmpx_imm (guint8 *code, int sreg, int imm)
+-{
+-	if (imm == 0) {
+-		arm_cmpx (code, sreg, ARMREG_RZR);
+-	} else {
+-		// FIXME:
+-		code = emit_imm (code, ARMREG_LR, imm);
+-		arm_cmpx (code, sreg, ARMREG_LR);
+-	}
+-
+-	return code;
+-}
+-
+ static __attribute__ ((__warn_unused_result__)) guint8*
+ emit_strb (guint8 *code, int rt, int rn, int imm)
+ {
+-- 
+2.51.0
+


### PR DESCRIPTION
This also updates mono from 6.12.0.199 to 6.14.1, while importing 3 patches needed for successful compilation on aarch64:

https://gitlab.winehq.org/mono/mono/-/merge_requests/101

Please do not merge this PR directly. Instead, create the `branch/25.08` branch manually.

Thanks.